### PR TITLE
Bug fix: Free memory when clearing variant typed variant.

### DIFF
--- a/src/dn_common.c
+++ b/src/dn_common.c
@@ -175,6 +175,7 @@ HRESULT SafeArrayDestroy(SAFEARRAY *psa)
 					for(i = 0; i < psa->rgsabound[0].cElements; i++){
 						VariantClear(((VARIANT*)psa->pvData + i));
 					}
+                                        free(psa->pvData);
 					break;
 				default:
 					free(psa->pvData);


### PR DESCRIPTION
Open PR to have the change incorporated to ROS packages in later releases.